### PR TITLE
Revert "chore(deps): bump esbuild from 0.27.7 to 0.28.1 in /packages/cli in the npm_and_yarn group across 1 directory"

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "debounce": "^2.2.0",
     "dotenv": "^16.5.0",
     "envin": "workspace:*",
-    "esbuild": "^0.28.1",
+    "esbuild": "^0.27.2",
     "log-symbols": "^7.0.0",
     "mime-types": "^3.0.1",
     "next": "catalog:",


### PR DESCRIPTION
Reverts turbostarter/envin#84